### PR TITLE
Perform last pick automatically

### DIFF
--- a/modules/bot.py
+++ b/modules/bot.py
@@ -964,12 +964,14 @@ class Channel():
 
         if member in match.alpha_team[0:1]:
             team = match.alpha_team
+            enemy_team = match.beta_team
             if match.pick_order:
                 if match.pick_order[match.pick_step] == "b":
                     client.reply(self.channel, member, "Not your turn to pick.")
                     return
         elif member in match.beta_team[0:1]:
             team = match.beta_team
+            enemy_team = match.alpha_team
             if match.pick_order:
                 if match.pick_order[match.pick_step] == "a":
                     client.reply(self.channel, member, "Not your turn to pick.")
@@ -1018,6 +1020,12 @@ class Channel():
             client.reply(self.channel, member, "Specified player are not in unpicked players list.")
         else:
             client.reply(self.channel, member, "You must specify a player to pick!")
+
+        if len(match.unpicked) == 1:
+            last_player = match.unpicked[0]
+            enemy_team.append(last_player)
+            match.unpicked.remove(last_player)
+            match.next_state()
 
     async def put_player(self, member, args, access_level):
         if not access_level:


### PR DESCRIPTION
## context
Addresses issue #2 

During the pick phase, the last unpicked player is still required to be picked via .pick <player>. This is unnecessary as there are no options besides the last player. This last unpicked player should automatically be assigned to the team that picks last.

## example
during 2v2 pick phase:

* players 1, 2, 3, 4 are in the game.
* player 1 and 2 are captains.
* captain 2 picks player 3.
* only player 4 remains.

without this change:
* captain 1 .picks player 4

with this change:
* the bot automatically assigns captain 1 player 4 (the only remaining player).

Warning: This is untested!