### PR TITLE
Allow players to remove themselves from active matches

### DIFF
--- a/modules/bot.py
+++ b/modules/bot.py
@@ -792,6 +792,7 @@ class Channel():
     def remove_player(self, member, args, reason='online'):
         changes = []
         allpickups = True
+        allow_remove_from_active_matches = True
 
         #add pickups from pickup_groups
         for i in list(args):
@@ -809,6 +810,12 @@ class Channel():
                 elif allpickups:
                     allpickups = False
 
+        if allow_remove_from_active_matches:
+            for match in list(active_matches):
+                if member.id in [i.id for i in match.players]:
+                    if match.channel.id == self.id and (args == [] or pickup.name.lower() in args):
+                        match.players.remove(member)
+                        match.ready_fallback()
         #update topic and warn player
         if changes != []:
             self.update_topic()

--- a/modules/bot.py
+++ b/modules/bot.py
@@ -815,7 +815,14 @@ class Channel():
                 if member.id in [i.id for i in match.players]:
                     if match.channel.id == self.id and (args == [] or pickup.name.lower() in args):
                         match.players.remove(member)
+                        client.notice(
+                            match.channel,
+                            "**{0}** is not ready!\r\nReverting **{1}** to gathering state...".format(
+                                member.nick or member.name, match.pickup.name
+                            )
+                        )
                         match.ready_fallback()
+
         #update topic and warn player
         if changes != []:
             self.update_topic()

--- a/modules/bot.py
+++ b/modules/bot.py
@@ -817,7 +817,7 @@ class Channel():
                         match.players.remove(member)
                         client.notice(
                             match.channel,
-                            "**{0}** is not ready!\r\nReverting **{1}** to gathering state...".format(
+                            "**{0}** left during pick phase! Reverting **{1}** to gathering state...".format(
                                 member.nick or member.name, match.pickup.name
                             )
                         )


### PR DESCRIPTION
This PR addresses issue https://github.com/UT2004-Coding-Projects/Hv-PugBot/issues/11: allowing players to be removed during the pick phase of a match. This phase occurs once a pickup becomes full, and a match gets created. The pickup object gets removed from `active_pickups` while the newly created `Match` object gets added to the `active_matches` list. In order to allow a player to be removed by one of its remove aliases:

- `--`
- `.lva`
- `.lv`

the `remove_player` function needs to be updated to also remove the player from not just pickups (unstarted, unfull) but also matches (in waiting_ready, picking states). This PR introduces that change to `remove_player` function to now
- remove player from the `match.players` list
- call `match.ready_fallback()` which handles putting players in a match back into their original pickup, while removing the `Match` from `active_matches`.