### PR TITLE
Add more clear message when pickup game type is not found

### DIFF
--- a/modules/bot.py
+++ b/modules/bot.py
@@ -863,13 +863,16 @@ class Channel():
             client.reply(self.channel, member, "You have no right for this!")
 
     def who(self, member, args):
-        templist=[]
+        templist = []
         for pickup in ( pickup for pickup in self.pickups if pickup.players != [] and (pickup.name.lower() in args or args == [])):
             templist.append('[**{0}** ({1}/{2})] {3}'.format(pickup.name, len(pickup.players), pickup.cfg['maxplayers'], '/'.join(["`"+(i.nick or i.name).replace("`","")+"`" for i in pickup.players])))
         if templist != []:
             client.notice(self.channel, ' '.join(templist))
         else:
-            client.notice(self.channel, 'no one added...ZzZz')
+            if args:
+                client.notice(self.channel, 'No pickups named {} found.'.format(', '.join(args)))
+            else:
+                client.notice(self.channel, 'no one added...ZzZz')
 
     def user_start_pickup(self, member, args, access_level):
         target = None

--- a/modules/bot.py
+++ b/modules/bot.py
@@ -872,7 +872,7 @@ class Channel():
             if args:
                 client.notice(self.channel, 'No pickups named {} found.'.format(', '.join(args)))
             else:
-                client.notice(self.channel, 'no one added...ZzZz')
+                client.notice(self.channel, 'No active pickups found.')
 
     def user_start_pickup(self, member, args, access_level):
         target = None


### PR DESCRIPTION
.who and .list when passed along with an argument like `.tdm4` imply that the bot should list players in that pickup game type. When a pickup is not found this currently returns a message `no one added...ZzZz`.

This change simply handles this scenario and ensures `No pickup named X found.` message is returned instead.

.who and .list when there are 0 pickups still will also instead provide a more clear message of `No active pickups found.`. A lot better than "no one added...ZzZz".