### PR TITLE
Fix broken fallback for ready required matches

### DIFF
--- a/modules/bot.py
+++ b/modules/bot.py
@@ -485,10 +485,7 @@ class Match():
             client.delete_message(self.ready_message)
             self.next_state()
 
-    def ready_fallback(self): #if ready event failed
-        if self.ready_message:
-            waiting_reactions.pop(self.ready_message.id)
-            client.delete_message(self.ready_message)
+    def pickup_fallback(self):
         active_matches.remove(self)
         newplayers = list(self.pickup.players)
         self.pickup.players = list(self.players)
@@ -500,6 +497,13 @@ class Match():
         if len(self.pickup.players):
             active_pickups.append(self.pickup)
         self.pickup.channel.update_topic()
+
+    def ready_fallback(self): #if ready event failed
+        if self.ready_message:
+            waiting_reactions.pop(self.ready_message.id)
+            client.delete_message(self.ready_message)
+
+        self.pickup_fallback()
 
     def ready_end(self):
         #client.notice(self.channel, "All players ready @ **{0}** pickup!".format(self.pickup.name))
@@ -901,7 +905,7 @@ class Channel():
                                 member.nick or member.name, match.pickup.name
                             )
                         )
-                        match.ready_fallback()
+                        match.fallback()
 
         #update topic and warn player
         if changes != []:

--- a/modules/bot.py
+++ b/modules/bot.py
@@ -905,7 +905,7 @@ class Channel():
                                 member.nick or member.name, match.pickup.name
                             )
                         )
-                        match.fallback()
+                        match.pickup_fallback()
 
         #update topic and warn player
         if changes != []:


### PR DESCRIPTION
The `ready_fallback` function was designed for falling back to pickup gathering phase + adding any queued up players into a pickup after a failed `ready` check phase. We appropriated it for also handling falling back to gathering phase during the captain's pick phase (a phase after the ready phase) so that players can leave a pug and the pug can keep all remaining players + add any queued up ones.

This didn't work as intended since the `ready_fallback` function attempts to remove ready reactions that exist during the ready phase. Instead `ready_fallback` call when a player removed themselves failed and error'd out, leaving pickups in a weird phase (both the pickup with the removed player existed and the queued up pickup existed at the same time). This would put the first pickup in limbo as any player that attempted to join it would join the 2nd pickup.

This PR introduces a small change to fix this. We rip out the fallback functionality into a fallback() function and create a secondary function and repurpose `ready_fallback` to remove ready reactions *and* then call a `fallback` function.