### PR TITLE
Prevent Monty from breaking pickup during ready phase

### DIFF
--- a/modules/bot.py
+++ b/modules/bot.py
@@ -876,7 +876,6 @@ class Channel():
     def remove_player(self, member, args, reason='online'):
         changes = []
         allpickups = True
-        allow_remove_from_active_matches = True
 
         #add pickups from pickup_groups
         for i in list(args):
@@ -894,10 +893,12 @@ class Channel():
                 elif allpickups:
                     allpickups = False
 
-        if allow_remove_from_active_matches:
-            for match in list(active_matches):
-                if member.id in [i.id for i in match.players]:
-                    if match.channel.id == self.id and (args == [] or pickup.name.lower() in args):
+        for match in list(active_matches):
+            if member.id in [i.id for i in match.players]:
+                if match.channel.id == self.id and (args == [] or pickup.name.lower() in args):
+                    if match.state == 'waiting_ready':
+                        match.ready_notready(member)
+                    else:
                         match.players.remove(member)
                         client.notice(
                             match.channel,


### PR DESCRIPTION
When a match is in `waiting_ready` state: waiting for players to hit the ready reactions, previously they would not be allowed to leave as the leave command only works for pickups and not `matches`. However, with the recent features added that allows players to leave during the pick phase, it also unintentionally let players leave during the ready phase through an abnormal procedure.

We still want to allow players to leave during the ready phase by typing `.lva` or `--`, so we just need to normalize the procedure by using the same calls that occur when a player hits the not-ready reaction.